### PR TITLE
test(frontend-admin): add sidebar navigation tests

### DIFF
--- a/frontend-admin/src/components/layout/__tests__/Sidebar.test.jsx
+++ b/frontend-admin/src/components/layout/__tests__/Sidebar.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import Sidebar from '../Sidebar';
+
+describe('Sidebar Component', () => {
+  const renderWithRouter = (component) => {
+    return render(<BrowserRouter>{component}</BrowserRouter>);
+  };
+
+  it('renders navigation links correctly', () => {
+    renderWithRouter(<Sidebar />);
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Inviti')).toBeInTheDocument();
+    expect(screen.getByText('Alloggi')).toBeInTheDocument();
+    expect(screen.getByText('Configurazione')).toBeInTheDocument();
+    expect(screen.getByText('Logout')).toBeInTheDocument();
+  });
+
+  it('applies active class to current route', () => {
+    // Manually set URL to /dashboard to test active state
+    window.history.pushState({}, 'Test Page', '/dashboard');
+    renderWithRouter(<Sidebar />);
+
+    const dashboardLink = screen.getByText('Dashboard').closest('a');
+    expect(dashboardLink).toHaveClass('bg-pink-50');
+    expect(dashboardLink).toHaveClass('text-pink-700');
+
+    const invitationsLink = screen.getByText('Inviti').closest('a');
+    expect(invitationsLink).not.toHaveClass('bg-pink-50');
+  });
+});


### PR DESCRIPTION
Adds unit tests for Sidebar navigation component in frontend-admin.
Covers:
- Rendering of navigation links
- Active class application based on route
