### PR TITLE
chore(deps): bump PaulHatch/semantic-version in the github-actions group

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Calculate Next Version
         id: calc_version
-        uses: PaulHatch/semantic-version@v6.0.0
+        uses: PaulHatch/semantic-version@v6.0.1
         with:
           tag_prefix: ""
           major_pattern: "BREAKING CHANGE:"


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [PaulHatch/semantic-version](https://github.com/paulhatch/semantic-version).


Updates `PaulHatch/semantic-version` from 6.0.0 to 6.0.1
- [Release notes](https://github.com/paulhatch/semantic-version/releases)
- [Changelog](https://github.com/PaulHatch/semantic-version/blob/master/CHANGELOG.md)
- [Commits](https://github.com/paulhatch/semantic-version/compare/v6.0.0...v6.0.1)

---
updated-dependencies:
- dependency-name: PaulHatch/semantic-version dependency-version: 6.0.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: github-actions ...