### PR TITLE
refactor(core): aggiorna logica calcolo costi dashboard e pulizia viste

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,22 +23,20 @@
     }
   ],
   "python.testing.pytestArgs": [
-    "-c",
-    "./backend/pytest.ini"
+    "."
   ],
   "python.testing.unittestEnabled": false,
-  "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python",
+  "python.defaultInterpreterPath": "backend/.venv/bin/python",
   "python.analysis.extraPaths": [
-    "${workspaceFolder}/backend"
+    "backend"
   ],
-  "python.envFile": "${workspaceFolder}/backend/.venv",
+  "python.analysis.autoImportCompletions": true,
   // Linting & Formatting
   "python.linting.enabled": true,
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,
   "python.formatting.provider": "black",
   // Django Support
-  "python.analysis.autoImportCompletions": true,
   "files.associations": {
     "**/templates/**/*.html": "django-html",
     "**/templates/**/*.txt": "django-txt"

--- a/frontend-admin/src/pages/InvitationList.jsx
+++ b/frontend-admin/src/pages/InvitationList.jsx
@@ -587,7 +587,7 @@ const InvitationList = () => {
                           {invitation.guests?.map((guest, idx) => (
                             <span
                               key={guest.id || idx}
-                              className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium border ${invitation.status === 'declined'
+                              className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium border ${(invitation.status === 'declined' || guest.not_coming)
                                 ? 'bg-red-50 text-red-400 border-red-100 line-through opacity-70'
                                 : guest.is_child
                                   ? 'bg-pink-50 text-pink-700 border-pink-100'
@@ -818,7 +818,11 @@ const InvitationList = () => {
                     {invitation.guests?.map((g, idx) => (
                       <span
                         key={idx}
-                        className="text-xs bg-slate-100 px-2 py-1 rounded text-slate-600 border border-slate-200 flex items-center"
+                        className={`inline-flex items-center px-2 py-1 rounded-md text-xs font-medium border ${(invitation.status === 'declined' || g.not_coming)
+                          ? 'bg-red-50 text-red-400 border-red-100 line-through opacity-70'
+                          : g.is_child
+                            ? 'bg-pink-50 text-pink-700 border-pink-100'
+                            : 'bg-slate-50 text-slate-700 border-slate-200'}`}
                       >
                         {g.is_child ? <Baby size={10} className="mr-1" /> : <User size={10} className="mr-1" />}
                         {g.first_name}


### PR DESCRIPTION
- Rimosse GlobalConfigViewSet e WhatsAppTemplateViewSet (inutilizzate o spostate).
- Riscritta la logica di `calculate_cost` in `DashboardStatsView`:
    - Il calcolo ora accetta QuerySet invece di semplici contatori.
    - Introdotta logica per calcolare il costo esatto delle stanze assegnate (`assigned_room`) usando il prezzo specifico della stanza.
    - Fallback sul prezzo di configurazione globale per ospiti senza stanza assegnata ma con alloggio richiesto/offerto.
    - Affinato il calcolo dei costi per i transfer basato sugli stati di conferma e offerta.
- Ottimizzazione delle query:
    - Aggiunto `select_related('invitation', 'assigned_room')` per evitare query N+1.
    - Sostituiti i loop Python con filtri database per il conteggio di alloggi e transfer.